### PR TITLE
Allow custom HOST and use SSL on production

### DIFF
--- a/client/src/states/Mainmenu.js
+++ b/client/src/states/Mainmenu.js
@@ -45,7 +45,7 @@ class MainmenuState extends Phaser.State {
             }
         });
 
-        const connectUrl = `http://${config.HOST}:${config.CONNECT_PORT}`;
+        const connectUrl = (process.env.ENV == 'prod' ? 'https://' : "http://") + `${config.HOST}:${config.CONNECT_PORT}`;
         this.socket = io(connectUrl);
 
         this.socket.on('connect', () => {

--- a/common/config.js
+++ b/common/config.js
@@ -3,15 +3,16 @@ let connect_port;
 let listen_port;
 const so_env = process.env.SO_ENV || SO_ENV;
 console.log('SO_ENV:', so_env);
+console.log('HOST is ', process.env.HOST || 'localhost');
 
 if (so_env === 'dev') {
     host = 'localhost';
     listen_port = connect_port = 8080;
 }
 else if (so_env === 'prod' ) {
-    host = 'sqoff.com';
+    host = process.env.HOST || 'sqoff.com';
     listen_port = 8080;
-    connect_port = 80;
+    connect_port = 443;
 }
 
 const config = {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -127,6 +127,8 @@ async function build() {
         .pipe(gulpif(!isProduction(), exorcist(sourcemapPath)))
         .pipe(source(OUTPUT_FILE))
         .pipe(buffer())
+        .pipe(gulpif(isProduction(),replace('process.env.HOST', JSON.stringify(process.env.HOST || 'sqoff.com'))))
+        .pipe(gulpif(isProduction(),replace('process.env.ENV', JSON.stringify(process.env.ENV || 'dev'))))
         .pipe(gulpif(isProduction(), terser()))
         .pipe(gulp.dest(SCRIPTS_PATH));
 }

--- a/server/server.js
+++ b/server/server.js
@@ -95,7 +95,7 @@ var MainServer = function () {
         const httpServer = http.createServer(app);
         const options = {
             cors: {
-                origin: "http://" + config.HOST,
+                origin: (process.env.ENV == 'prod' ? 'https://' : "http://") + config.HOST,
                 methods: ["GET", "POST"]
             }
         };


### PR DESCRIPTION
Previous prod behavior hard codes sqoff.com as the host.  These changes allow deployment on any domain.